### PR TITLE
feat: add support for GNOME 44

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -41,7 +41,6 @@ class Extension {
                 canmaximize: focusedWindow.meta_window.can_maximize(),
                 maximized: focusedWindow.meta_window.get_maximized(),
                 canminimize: focusedWindow.meta_window.can_minimize(),
-                canshade: focusedWindow.meta_window.can_shade(),
                 display: focusedWindow.meta_window.get_display(),
                 frame_type: focusedWindow.meta_window.get_frame_type(),
                 window_type: focusedWindow.meta_window.get_window_type(),

--- a/metadata.json
+++ b/metadata.json
@@ -4,5 +4,5 @@
   "uuid": "focused-window-dbus@flexagoon.com",
   "version": 2,
   "url": "https://github.com/flexagoon/focused-window-dbus",
-  "shell-version": ["43"]
+  "shell-version": ["43", "44"]
 }


### PR DESCRIPTION
Add "`44`" to the metadata of the extension, and remove the `canshade` property since it is not available on GNOME 44. I'm not sure of what was indicated by `canshade`, but I can look into a replacement (instead of removing it) if you believe it to be an important feature.

Thank you for developing this awesome extension and making GNOME compatible with ActivityWatch! ⌚🚀  