### PR TITLE
fix: support GNOME 45

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,4 +1,4 @@
-import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
+import { Extension, gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js';
 import Gio from 'gi://Gio';
 
 const DBUS_SCHEMA = `
@@ -75,6 +75,6 @@ export default class MyExtension extends Extension {
 
 function init() {
     let extensionInstance = new MyExtension();
-    log(`initializing ${extensionInstance.metadata.name}`);
+    console.log(_(`initializing ${extensionInstance.metadata.name}`));
     return extensionInstance;
 }

--- a/extension.js
+++ b/extension.js
@@ -1,8 +1,8 @@
 "use strict";
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const Gio = imports.gi.Gio;
+import Extension from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as MyModule from './extension.js';
+import Gio from 'gi://Gio';
 
 const DBUS_SCHEMA = `
 <node>
@@ -13,7 +13,7 @@ const DBUS_SCHEMA = `
     </interface>
 </node>`;
 
-class Extension {
+export default class MyExtension {
   Get() {
     let window_list = global.get_window_actors();
     let focusedWindow = window_list.find((window) =>
@@ -77,6 +77,6 @@ class Extension {
 }
 
 function init() {
-  log(`initializing ${Me.metadata.name}`);
-  return new Extension();
+    log(`initializing ${MyModule.metadata.name}`);
+    return new MyExtension();
 }

--- a/extension.js
+++ b/extension.js
@@ -1,7 +1,4 @@
-"use strict";
-
-import Extension from 'resource:///org/gnome/shell/extensions/extension.js';
-import * as MyModule from './extension.js';
+import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 import Gio from 'gi://Gio';
 
 const DBUS_SCHEMA = `
@@ -13,7 +10,7 @@ const DBUS_SCHEMA = `
     </interface>
 </node>`;
 
-export default class MyExtension {
+export default class MyExtension extends Extension {
   Get() {
     let window_list = global.get_window_actors();
     let focusedWindow = window_list.find((window) =>
@@ -77,6 +74,7 @@ export default class MyExtension {
 }
 
 function init() {
-    log(`initializing ${MyModule.metadata.name}`);
-    return new MyExtension();
+    let extensionInstance = new MyExtension();
+    log(`initializing ${extensionInstance.metadata.name}`);
+    return extensionInstance;
 }

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "Focused Window D-Bus",
   "description": "Exposes a D-Bus method to get active window title and class",
   "uuid": "focused-window-dbus@flexagoon.com",
-  "version": 4,
+  "version": 5,
   "url": "https://github.com/flexagoon/focused-window-dbus",
-  "shell-version": ["43", "44"]
+  "shell-version": ["45"]
 }


### PR DESCRIPTION
@flexagoon 

This works for the main purpose of the extension (getting the window info via D-Bus). It is working for me with my app on Fedora 39 beta with GNOME 45. But I can't get anything to come out in the journal no matter what I try. So if you care about the logging output you'll need to take a look at it. 

Updates import lines to conform to the ECM6 method adopted by GNOME 45. 

A source stated that the "use strict"; is redundant with ECM6 modules, so I removed it. 

Bumped the version number to "5" to go along with the GNOME version, and restricted the `shell-version` to just "45" since this is a breaking change that makes the code incompatible with any GNOME shell earlier than 45. But the same code should be good for future GNOME versions now that they've standardized on the ECM6 import style. 

Current main branch should be saved in a new branch before merging this, to preserve the state of the extension for GNOME 44 and earlier. 
