### PR TITLE
Update for GNOME 47, version bump

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "Focused Window D-Bus",
   "description": "Exposes a D-Bus method to get active window title and class",
   "uuid": "focused-window-dbus@flexagoon.com",
-  "version": 6,
+  "version": 7,
   "url": "https://github.com/flexagoon/focused-window-dbus",
-  "shell-version": ["45", "46"]
+  "shell-version": ["45", "46", "47"]
 }


### PR DESCRIPTION
@flexagoon 

It's that time again. 

Testing on Fedora Rawhide in the GNOME 47 beta, there is no apparent issue using the extension after updating the metadata file to allow it to be enabled. 

Added a version bump to match. 
