### PR TITLE
Add support for GNOME 40/41/42

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,13 @@
   "name": "Focused Window D-Bus",
   "description": "Exposes a D-Bus method to get active window title and class",
   "uuid": "focused-window-dbus@flexagoon.com",
-  "version": 4,
+  "version": 5,
   "url": "https://github.com/flexagoon/focused-window-dbus",
-  "shell-version": ["43", "44"]
+  "shell-version": [
+      "40",
+      "41",
+      "42",
+      "43",
+      "44"
+  ]
 }


### PR DESCRIPTION
@flexagoon 

I did an experiment on AlmaLinux 9 to test a theory, and it turned out that the pre-GNOME 45 version of the extension works fine in GNOME 40, just like the Xremap extension. Which pretty much means it works from 40-44. It may even work in GNOME 3.38 but I don't have a Zorin 16 VM right now to test that. I'd have to go pretty far back in Ubuntu releases to find a version with 3.38, but I know Zorin was stuck on that version until very recently. 

Anyway, this is not really important at all, but would make your extension usable on a ton of distros based around RHEL 9. Such as AlmaLinux 9, Rocky 9, EuroLinux 9, CentOS Stream 9, and something I just heard about recently: Oreon Lime R2 (based on AlmaLinux 9.3). They're all stuck with GNOME 40.x until RHEL v10 comes out (and nobody knows when that might be). I think there are also some other LTS distros that are stuck somewhere in the GNOME 40-42 range. 

Good thing you kept the separate branch of the pre-45 version. Should be a pretty simple update if you're interested in expanding compatibility. 
