### PR TITLE
Update for GNOME 48, version bump

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "Focused Window D-Bus",
   "description": "Exposes a D-Bus method to get active window title and class",
   "uuid": "focused-window-dbus@flexagoon.com",
-  "version": 7,
+  "version": 8,
   "url": "https://github.com/flexagoon/focused-window-dbus",
-  "shell-version": ["45", "46", "47"]
+  "shell-version": ["45", "46", "47", "48"]
 }


### PR DESCRIPTION
@flexagoon 

No problem observed in GNOME 48 on Fedora Rawhide, after manually adding "48" to shell versions list. 

Fedora 42 with GNOME 48 should be available as a beta release shortly. Time to update the extension again. 
