### PR TITLE
Fix crash when logical monitor is null

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -10,6 +10,19 @@ const DBUS_SCHEMA = `
     </interface>
 </node>`;
 
+// Helper function to safely get work area properties.
+// These methods can trigger a fatal assertion in Mutter if the window's
+// logical monitor is null (e.g., during monitor hotplug or display
+// reconfiguration), causing GNOME Shell to crash.
+function safeGetWorkArea(metaWindow, method, ...args) {
+  try {
+    return metaWindow[method](...args);
+  } catch (e) {
+    // Return null if the logical monitor is invalid
+    return null;
+  }
+}
+
 export default class FocusedWindowDbus extends Extension {
   Get() {
     let window_list = global.get_window_actors();
@@ -48,10 +61,9 @@ export default class FocusedWindowDbus extends Extension {
         layer: focusedWindow.meta_window.get_layer(),
         monitor: focusedWindow.meta_window.get_monitor(),
         role: focusedWindow.meta_window.get_role(),
-        area: focusedWindow.meta_window.get_work_area_current_monitor(),
-        area_all: focusedWindow.meta_window.get_work_area_all_monitors(),
-        area_cust:
-          focusedWindow.meta_window.get_work_area_for_monitor(currentmonitor),
+        area: safeGetWorkArea(focusedWindow.meta_window, 'get_work_area_current_monitor'),
+        area_all: safeGetWorkArea(focusedWindow.meta_window, 'get_work_area_all_monitors'),
+        area_cust: safeGetWorkArea(focusedWindow.meta_window, 'get_work_area_for_monitor', currentmonitor),
       });
     } else {
       return "{}";

--- a/extension.js
+++ b/extension.js
@@ -11,12 +11,11 @@ const DBUS_SCHEMA = `
 </node>`;
 
 // Check if a window has a valid logical monitor.
-// The get_work_area_* methods will trigger a fatal assertion in Mutter
-// (meta_window_get_work_area_for_logical_monitor) if the window's logical
-// monitor is null. This can happen during monitor hotplug, display
-// reconfiguration, or when windows are in transient states.
-// We MUST check this BEFORE calling those methods because the assertion
-// calls abort() at the C level, which cannot be caught by JavaScript try/catch.
+// The get_work_area_* methods will trigger a fatal assertion in Mutter if the window's
+// logical monitor is null. This can happen during monitor hotplug, display reconfiguration,
+// or when windows are in transient states. We MUST check this BEFORE calling those methods
+// because the assertion calls abort() at the C level, which cannot be caught by JavaScript try/catch.
+// See: https://github.com/flexagoon/focused-window-dbus/pull/12
 function hasValidMonitor(metaWindow) {
   const windowMonitor = metaWindow.get_monitor();
   // Monitor index is -1 if the window has no monitor assigned
@@ -43,7 +42,6 @@ export default class FocusedWindowDbus extends Extension {
     let workspaceManager = global.workspace_manager;
     let currentmonitor = global.display.get_current_monitor();
     if (focusedWindow) {
-      // Check if window has a valid monitor before calling work area methods
       const validMonitor = hasValidMonitor(focusedWindow.meta_window);
 
       return JSON.stringify({

--- a/extension.js
+++ b/extension.js
@@ -10,17 +10,25 @@ const DBUS_SCHEMA = `
     </interface>
 </node>`;
 
-// Helper function to safely get work area properties.
-// These methods can trigger a fatal assertion in Mutter if the window's
-// logical monitor is null (e.g., during monitor hotplug or display
-// reconfiguration), causing GNOME Shell to crash.
-function safeGetWorkArea(metaWindow, method, ...args) {
-  try {
-    return metaWindow[method](...args);
-  } catch (e) {
-    // Return null if the logical monitor is invalid
-    return null;
+// Check if a window has a valid logical monitor.
+// The get_work_area_* methods will trigger a fatal assertion in Mutter
+// (meta_window_get_work_area_for_logical_monitor) if the window's logical
+// monitor is null. This can happen during monitor hotplug, display
+// reconfiguration, or when windows are in transient states.
+// We MUST check this BEFORE calling those methods because the assertion
+// calls abort() at the C level, which cannot be caught by JavaScript try/catch.
+function hasValidMonitor(metaWindow) {
+  const windowMonitor = metaWindow.get_monitor();
+  // Monitor index is -1 if the window has no monitor assigned
+  if (windowMonitor < 0) {
+    return false;
   }
+  // Also verify the monitor index is within bounds
+  const numMonitors = global.display.get_n_monitors();
+  if (windowMonitor >= numMonitors) {
+    return false;
+  }
+  return true;
 }
 
 export default class FocusedWindowDbus extends Extension {
@@ -35,6 +43,9 @@ export default class FocusedWindowDbus extends Extension {
     let workspaceManager = global.workspace_manager;
     let currentmonitor = global.display.get_current_monitor();
     if (focusedWindow) {
+      // Check if window has a valid monitor before calling work area methods
+      const validMonitor = hasValidMonitor(focusedWindow.meta_window);
+
       return JSON.stringify({
         title: focusedWindow.meta_window.get_title(),
         wm_class: focusedWindow.meta_window.get_wm_class(),
@@ -61,9 +72,10 @@ export default class FocusedWindowDbus extends Extension {
         layer: focusedWindow.meta_window.get_layer(),
         monitor: focusedWindow.meta_window.get_monitor(),
         role: focusedWindow.meta_window.get_role(),
-        area: safeGetWorkArea(focusedWindow.meta_window, 'get_work_area_current_monitor'),
-        area_all: safeGetWorkArea(focusedWindow.meta_window, 'get_work_area_all_monitors'),
-        area_cust: safeGetWorkArea(focusedWindow.meta_window, 'get_work_area_for_monitor', currentmonitor),
+        // Only call work area methods if window has a valid monitor
+        area: validMonitor ? focusedWindow.meta_window.get_work_area_current_monitor() : null,
+        area_all: validMonitor ? focusedWindow.meta_window.get_work_area_all_monitors() : null,
+        area_cust: validMonitor ? focusedWindow.meta_window.get_work_area_for_monitor(currentmonitor) : null,
       });
     } else {
       return "{}";


### PR DESCRIPTION
> [!NOTE]
> **AI Assistance Disclosure:** This PR was created with assistance from Claude Opus 4.5 via Cursor. The crash analysis, diagnosis, and fix were AI-assisted based on actual crash logs from my system.

## Summary

Fixes #11

The `get_work_area_current_monitor()`, `get_work_area_all_monitors()`, and `get_work_area_for_monitor()` methods can trigger a fatal assertion in Mutter's `meta_window_get_work_area_for_logical_monitor()` if the window's logical monitor is null or invalid.

This can occur during:
- Monitor hotplug (connecting/disconnecting displays)
- Display configuration changes
- Windows in transient states between monitors

The assertion failure causes GNOME Shell to abort, crashing the entire desktop session.

## Changes

This PR wraps the work area calls in a helper function `safeGetWorkArea()` that catches any errors and returns `null` instead, preventing the crash.

## Testing

I experienced this crash on my system (GNOME Shell 49.2, NixOS). Unfortunately I cannot easily test the fix without waiting for another crash to occur naturally, but the change is minimal and defensive—it simply wraps the existing calls in try/catch blocks.

## Crash Log (for reference)

```
libmutter:ERROR:../src/core/window.c:6081:meta_window_get_work_area_for_logical_monitor: assertion failed: (logical_monitor)
#0   560760948308 i   file:///...extensions/focused-window-dbus@flexagoon.com/extension.js:51
```