### PR TITLE
fix: defer D-Bus export to idle to avoid GC sweep block on Wayland hybrid nvidia

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -88,26 +88,44 @@ export default class FocusedWindowDbus extends Extension {
   #windowTracker = null;
   #focusConnection = null;
 
+  #dbusIdleId = null;
+
   enable() {
     this.#windowTracker = Shell.WindowTracker.get_default();
     this.#focusConnection = this.#windowTracker.connect("notify::focus-app", () => {
-      this._dbus.emit_signal("FocusChanged", new GLib.Variant("(s)", [this.Get()]));
+      if (this._dbus)
+        this._dbus.emit_signal("FocusChanged", new GLib.Variant("(s)", [this.Get()]));
     })
 
-    this._dbus = Gio.DBusExportedObject.wrapJSObject(DBUS_SCHEMA, this);
-    this._dbus.export(
-      Gio.DBus.session,
-      "/org/gnome/shell/extensions/FocusedWindow"
-    );
+    // Defer D-Bus export to idle to avoid blocking Shell init's GC sweep
+    // (init.js:21 AsyncReadyCallback overlaps with export's g_dbus_connection_register_object)
+    // on Wayland hybrid nvidia (mutter 46.2 + nvidia-drm secondary). See flexagoon#17.
+    this.#dbusIdleId = GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
+      this._dbus = Gio.DBusExportedObject.wrapJSObject(DBUS_SCHEMA, this);
+      this._dbus.export(
+        Gio.DBus.session,
+        "/org/gnome/shell/extensions/FocusedWindow"
+      );
+      this.#dbusIdleId = null;
+      return GLib.SOURCE_REMOVE;
+    });
   }
 
   disable() {
-    this.#windowTracker.disconnect(this.#focusConnection);
+    if (this.#dbusIdleId) {
+      GLib.source_remove(this.#dbusIdleId);
+      this.#dbusIdleId = null;
+    }
+    if (this.#focusConnection && this.#windowTracker) {
+      this.#windowTracker.disconnect(this.#focusConnection);
+    }
     this.#focusConnection = null;
     this.#windowTracker = null;
 
-    this._dbus.flush();
-    this._dbus.unexport();
-    delete this._dbus;
+    if (this._dbus) {
+      this._dbus.flush();
+      this._dbus.unexport();
+      delete this._dbus;
+    }
   }
 }


### PR DESCRIPTION
Fixes #17

Wayland hybrid nvidia (i915 + nvidia-drm secondary, mutter 46.2) wedges: `Gio.DBusExportedObject.export` in `enable()` overlaps `init.js:21` GC sweep → `Attempting to call back into JSAPI during GC sweep` (DBusSignalCallback), blocks loginManager inhibit, black screen, frozen tty2. X11 greeter works.

Defer export via `GLib.idle_add(PRIORITY_DEFAULT_IDLE)`, guard emit with `if (this._dbus)`, handle disable race with `source_remove`.

**Try before merge with forkhub:**
```bash
pnpm dlx "github:ImBIOS/forkhub#canary&path:packages/cli" fh --help
fh import https://github.com/ImBIOS/.forkhub/blob/main/repos/github.com/flexagoon/focused-window-dbus/patches/defer-d-bus-export-to-idle-to-avoid-gc-sweep-block-yt50fhbb/INTENT.md
```